### PR TITLE
query.jsp的url传参以及Servlet中query方法的逻辑判断

### DIFF
--- a/src/servlet/CustomerServlet.java
+++ b/src/servlet/CustomerServlet.java
@@ -118,6 +118,12 @@ public class CustomerServlet extends BaseServlet {
         Customer customer = CommonUtils.toBean(request.getParameterMap(), Customer.class);
 
 //        System.out.println(getUrl(request));
+        if(customer.getName()==null && customer.getGender()==null && customer.getEmail()==null && customer.getPhone()==null  ) {
+			c=(Customer)request.getSession().getAttribute("c");
+		}else {
+		c = encoding(c);
+		request.getSession().setAttribute("c", c);
+		}
         customer = encoding(customer);
 
         int pc = getPc(request);

--- a/web/query.jsp
+++ b/web/query.jsp
@@ -13,8 +13,8 @@
 </head>
 <body>
     <h3 align="center">高级搜索</h3>
-    <form action="<c:url value="/CustomerServlet"/>" method="get">
-        <input type="hidden" name="method" value="query">
+    <form action="<c:url value="/CustomerServlet?method=query"/>" method="get">	//Servlet中的getUrl方法需要读取到menthod参数
+        
         <table border="0" align="center" width="40%" style="margin-left: 100px">
             <tr>
                 <td width="100px">客户名称</td>


### PR DESCRIPTION
1. query.jsp中，因为在getUrl要捕获到url中的method的值，所以不能在input把此参数用post方式传给Servlet处理。
2. query方法中，每次应该要判断是点击了分页还是开始了新的高级搜索，否则在搜索结果中点击其他页数，而query中没有重新接收到任何限制语句，就重新搜索出所有的结果，